### PR TITLE
clearing SelectedDates that aren't visible at time of selection

### DIFF
--- a/XamForms.Controls.Calendar/Calendar.xaml.cs
+++ b/XamForms.Controls.Calendar/Calendar.xaml.cs
@@ -884,6 +884,7 @@ namespace XamForms.Controls
 			if (!MultiSelectDates)
 			{
 				buttons.FindAll(b => b.IsSelected).ForEach(b => ResetButton(b));
+				SelectedDates.Clear();
 			}
 
 			var deselect = button.IsSelected;


### PR DESCRIPTION
#11 

SelectedDates that are in other months than the one currently being viewed won't be deselected when a new date is selected because they are not represented by buttons at that moment (they are not visible) so the hook to find and deselect them won't find them.